### PR TITLE
Update Sample to include paging

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ AVEVA Data Hub is secured by obtaining tokens from its identity endpoint. Client
 }
 ```
 
-Within the sample, there are configurable options for number of streams to create, the signup name, query parameters, and number of additional signups to create.
+Within the sample, there are configurable options for number of streams to create, the signup name, query parameters, and number of additional signups to create. Please note: the maximum value for the count query parameter is 1,000 for get all signups and 10,000 for get signup resources.
 
 ## Running the sample
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,10 @@ The sample will perform the following procedures:
 1. Make updates to the Streams (post data to stream)
 1. Make an API request to GetUpdates and ensure that data updates are received
 1. Create a new SDS Stream and make an API request to UpdateSignupResources to include the new stream
-1. Make an API request to GetSignupResources to view signup with updated resources
+1. Make an API request to GetSignupResources using query parameters to view signup with updated resources
 1. Make an API request to GetUpdates using the bookmark from the previous GetUpdates response
-1. Cleanup signup, streams, and type
+1. Create additional signups that are in an acitvating state and make an API request to GetAllSignups with skip and count query parameters
+1. Cleanup signups, streams, and type
 
 NOTE: Communication with SDS will be done via the .NET OCS Clients Library. Communication with Streaming Updates will be done using Http.
 
@@ -48,7 +49,7 @@ AVEVA Data Hub is secured by obtaining tokens from its identity endpoint. Client
 }
 ```
 
-Within the sample, there are configurable options for number of streams to create and the signup name.
+Within the sample, there are configurable options for number of streams to create, the signup name, query parameters, and number of additional signups to create.
 
 ## Running the sample
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ The sample will perform the following procedures:
 1. Make an API request to GetUpdates and ensure that data updates are received
 1. Create a new SDS Stream and make an API request to UpdateSignupResources to include the new stream
 1. Make an API request to GetSignupResources using query parameters to view signup with updated resources
-1. Make an API request to GetUpdates using the bookmark from the previous GetUpdates response
-1. Create additional signups that are in an acitvating state and make an API request to GetAllSignups with skip and count query parameters
+1. Update streams using non-Insert operations
+1. Make an API request to GetUpdates using the bookmark from the previous GetUpdates response to demonstrate update retrieval of other operation types (for example, Replace, Update, Remove and RemoveWindow).
+1. Create additional signups and make an API request to GetAllSignups with query parameters to view all signups
 1. Cleanup signups, streams, and type
 
 NOTE: Communication with SDS will be done via the .NET OCS Clients Library. Communication with Streaming Updates will be done using Http.

--- a/StreamingUpdatesRestApi/Program.cs
+++ b/StreamingUpdatesRestApi/Program.cs
@@ -73,6 +73,7 @@ namespace StreamingUpdatesRestApi
             const int GetAllSignupsSkip = 0;
             const int GetAllSignupsCount = AdditionalSignupsToCreate + 1; // includes initial signup created.
 
+            // === Lists ===
             List<string> simpleStreamIdList = new List<string>();
             List<string> weatherDataStreamIdList = new List<string>();
             List<string> signupIds = new List<string>();
@@ -326,7 +327,7 @@ namespace StreamingUpdatesRestApi
                     #endregion
 
                     // Step 11
-                    // Populate streams using non-Insert operations
+                    // Update streams using non-Insert operations
                     #region Step11
                     Console.WriteLine("Step 11: Writing update, replace, remove and remove window operations to the streams");
 
@@ -351,7 +352,7 @@ namespace StreamingUpdatesRestApi
 
                     // Step 12
                     // Make a new API request to GetUpdates using the bookmark obtained from the previous GetUpdates response to
-                    // demonstrate update retrieval  other operation types (for example, Replace, Update, Remove and RemoveWindow).
+                    // demonstrate update retrieval of other operation types (for example, Replace, Update, Remove and RemoveWindow).
                     #region Step12
                     Console.WriteLine("Step 12: Get Updates");
 
@@ -381,7 +382,7 @@ namespace StreamingUpdatesRestApi
                     #endregion
 
                     // Step 13
-                    // Make an API request to Get All Signups with query parameters to view all signups
+                    // Create additional signups and make an API request to GetAllSignups with query parameters to view all signups
                     #region Step13
                     Console.WriteLine("Step 13: Get All Signups");
 
@@ -430,7 +431,7 @@ namespace StreamingUpdatesRestApi
                 finally
                 {
                     // Step 14
-                    // Cleanup Resources
+                    // Cleanup signups, streams, and type
                     #region Step14
                     Console.WriteLine("Step 14: Cleaning Up");
 

--- a/StreamingUpdatesRestApi/Program.cs
+++ b/StreamingUpdatesRestApi/Program.cs
@@ -65,13 +65,13 @@ namespace StreamingUpdatesRestApi
 
             // === Change these values to modify the query parameters for get signup resources ===
             const int GetSignupResourcesSkip = 0;
-            const int GetSignupResourcesCount = SimpleStreamsToCreate + WeatherDataStreamsToCreate;
+            const int GetSignupResourcesCount = SimpleStreamsToCreate + WeatherDataStreamsToCreate + 1; // Includes new stream to be created in Step 9.
             const SignupResourceFilter GetSignupsResourcesFilter = SignupResourceFilter.All;
 
             // === Change these values to modify the query parameters for get all signups ===
             const int AdditionalSignupsToCreate = 2;
             const int GetAllSignupsSkip = 0;
-            const int GetAllSignupsCount = AdditionalSignupsToCreate + 1; // includes initial signup created.
+            const int GetAllSignupsCount = AdditionalSignupsToCreate + 1; // Includes initial signup created in Step 4.
 
             // === Lists ===
             List<string> simpleStreamIdList = new List<string>();
@@ -387,7 +387,6 @@ namespace StreamingUpdatesRestApi
                     Console.WriteLine("Step 13: Get All Signups");
 
                     // Create additional signups
-                    Console.WriteLine("Create Additional Signups to show in Get All Signups Call");
                     for (int i = 0; i < AdditionalSignupsToCreate; i++)
                     {
                         // The signup does not need to be active to view in Get All Signups. 
@@ -404,7 +403,6 @@ namespace StreamingUpdatesRestApi
                         CheckIfResponseWasSuccessful(response);
                     }
 
-                    Console.WriteLine("Make an API request to Get All Signups.");
                     response = await httpClient.GetAsync(new Uri($"{resource}/api/{apiVersion}/Tenants/{tenantId}/Namespaces/{namespaceId}/signups?skip={GetAllSignupsSkip}&count={GetAllSignupsCount}", UriKind.Absolute)).ConfigureAwait(false);
                     CheckIfResponseWasSuccessful(response);
 

--- a/StreamingUpdatesRestApi/Program.cs
+++ b/StreamingUpdatesRestApi/Program.cs
@@ -286,8 +286,8 @@ namespace StreamingUpdatesRestApi
                     {
                         SdsStream newSdsStream = new SdsStream()
                         {
-                            Id = WeatherDataStreamPrefix + "New",
-                            Name = WeatherDataStreamPrefix + "New",
+                            Id = WeatherDataStreamPrefix + "New_" + i,
+                            Name = WeatherDataStreamPrefix + "New_" + i,
                             TypeId = WeatherDataTypeId,
                             Description = $"New Weather Data Stream for ADH Streaming Updates",
                         };

--- a/StreamingUpdatesRestApi/Program.cs
+++ b/StreamingUpdatesRestApi/Program.cs
@@ -405,6 +405,9 @@ namespace StreamingUpdatesRestApi
                         additionalSignupToCreateString.Headers.ContentType = new MediaTypeHeaderValue("application/json");
                         response = await httpClient.PostAsync(new Uri($"{resource}/api/{apiVersion}/Tenants/{tenantId}/Namespaces/{namespaceId}/signups", UriKind.Absolute), additionalSignupToCreateString).ConfigureAwait(false);
                         CheckIfResponseWasSuccessful(response);
+
+                        Signup additionalSignup = JsonSerializer.Deserialize<Signup>(await response.Content.ReadAsStreamAsync().ConfigureAwait(false), _apiJsonOptions);
+                        signupIds.Add(additionalSignup?.Id);
                     }
 
                     response = await httpClient.GetAsync(new Uri($"{resource}/api/{apiVersion}/Tenants/{tenantId}/Namespaces/{namespaceId}/signups?skip={GetAllSignupsSkip}&count={GetAllSignupsCount}", UriKind.Absolute)).ConfigureAwait(false);
@@ -414,7 +417,6 @@ namespace StreamingUpdatesRestApi
 
                     foreach (var signupReturned in signups!.Signups)
                     {
-                        signupIds.Add(signupReturned.Id);
                         Console.WriteLine($"Signup: {signupReturned.Name}, Id: {signupReturned.Id}");
                     }
 
@@ -434,7 +436,7 @@ namespace StreamingUpdatesRestApi
                     #region Step14
                     Console.WriteLine("Step 14: Cleaning Up");
 
-                    foreach (var id in signupIds.Distinct())
+                    foreach (var id in signupIds)
                     {
                         Console.WriteLine($"Deleting ADH Signup with id {id}");
                         RunInTryCatch(httpClient.DeleteAsync, $"{resource}/api/{apiVersion}/Tenants/{tenantId}/Namespaces/{namespaceId}/signups/{id}");

--- a/StreamingUpdatesRestApi/Program.cs
+++ b/StreamingUpdatesRestApi/Program.cs
@@ -406,15 +406,12 @@ namespace StreamingUpdatesRestApi
                     response = await httpClient.GetAsync(new Uri($"{resource}/api/{apiVersion}/Tenants/{tenantId}/Namespaces/{namespaceId}/signups?skip={GetAllSignupsSkip}&count={GetAllSignupsCount}", UriKind.Absolute)).ConfigureAwait(false);
                     CheckIfResponseWasSuccessful(response);
 
-                    SignupsWrapper signupsWrapper = JsonSerializer.Deserialize<SignupsWrapper>(await response.Content.ReadAsStreamAsync().ConfigureAwait(false), _apiJsonOptions);
+                    SignupCollection signups = JsonSerializer.Deserialize<SignupCollection>(await response.Content.ReadAsStreamAsync().ConfigureAwait(false), _apiJsonOptions);
 
-                    if (signupsWrapper!.Signups.Any())
+                    foreach (var signupReturned in signups!.Signups)
                     {
-                        foreach (var signupReturned in signupsWrapper.Signups)
-                        {
-                            if (signupReturned.Id != signupId) signupIds.Add(signupReturned.Id);
-                            Console.WriteLine($"Signup: {signupReturned.Name}, Id: {signupReturned.Id}");
-                        }
+                        if (signupReturned.Id != signupId) signupIds.Add(signupReturned.Id);
+                        Console.WriteLine($"Signup: {signupReturned.Name}, Id: {signupReturned.Id}");
                     }
 
                     Console.WriteLine();

--- a/StreamingUpdatesRestApi/SignupCollection.cs
+++ b/StreamingUpdatesRestApi/SignupCollection.cs
@@ -1,6 +1,6 @@
 ﻿namespace StreamingUpdatesRestApi
 {
-    public class SignupsWrapper
+    public class SignupCollection
     {
         public IEnumerable<Signup> Signups { get; set; } = Enumerable.Empty<Signup>();
     }

--- a/StreamingUpdatesRestApi/SignupResourceFilter.cs
+++ b/StreamingUpdatesRestApi/SignupResourceFilter.cs
@@ -1,0 +1,26 @@
+﻿using System.Text.Json.Serialization;
+
+namespace StreamingUpdatesRestApi
+{
+    /// <summary>
+    /// Filter to be applied to Signup Resources.
+    /// </summary>
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum SignupResourceFilter
+    {
+        /// <summary>
+        /// Returns inaccessible signup resources.
+        /// </summary>
+        Inaccessible = 0,
+
+        /// <summary>
+        /// Returns accessible signup resources.
+        /// </summary>
+        Accessible = 1,
+
+        /// <summary>
+        /// Returns accessible and inaccessible signup resources.
+        /// </summary>
+        All = 2,
+    }
+}

--- a/StreamingUpdatesRestApi/SignupsWrapper.cs
+++ b/StreamingUpdatesRestApi/SignupsWrapper.cs
@@ -1,0 +1,7 @@
+﻿namespace StreamingUpdatesRestApi
+{
+    public class SignupsWrapper
+    {
+        public IEnumerable<Signup> Signups { get; set; } = Enumerable.Empty<Signup>();
+    }
+}


### PR DESCRIPTION
- Add paging for Get Signup Resources API call.  Uses skip and count query parameters for paging along with a resourceFilter query parameter allowing the user to specify: accessible, inaccessible, and all resources. 
- Add Get All Signups API call to sample with skip and count query parameters for paging. 
- Added resource model to wrap signups response for get all signups. 
- Added new Enum for Signup Resource filter to specify all, inaccessible, or accessible resources. 
- Updates README documentation to include new step for Get All Signups. 